### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN [SEC-58]

### DIFF
--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   draft-new-beta-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read  # GITHUB_TOKEN only needs read for initial checkout
     name: Draft a new Beta release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feat/')
@@ -23,9 +23,18 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and push changes
+
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set Node 16
@@ -45,6 +54,7 @@ jobs:
         id: create-release
         env:
           HUSKY: 0
+          BETA_VERSION: ${{ github.event.inputs.beta_version }}
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=beta-release
@@ -52,9 +62,9 @@ jobs:
           git fetch --tags origin
           git merge origin/master
           current_version=$(jq -r .version package.json)
-          
+
           npx standard-version --skip.commit --skip.tag --skip.changelog
-          new_version="$(jq -r .version package.json).beta.${{ github.event.inputs.beta_version }}"
+          new_version="$(jq -r .version package.json).beta.${BETA_VERSION}"
           git reset --hard
 
           branch_name="${release_type}/${new_version}"
@@ -66,7 +76,7 @@ jobs:
           echo "New release branch name is $branch_name"
           git checkout -b "$branch_name"
           git push --set-upstream origin "$branch_name"
-          
+
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
@@ -81,13 +91,14 @@ jobs:
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"
           npx replace $CURRENT_VERSION_VALUE $NEW_VERSION_VALUE package.json
-          git add package.json
-          echo ${{ steps.create-release.outputs.new_version }}
-          echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
-          git commit -m "chore(beta-relase): $NEW_VERSION_VALUE"
-          git tag -a "v$NEW_VERSION_VALUE" -m "chore: release v$NEW_VERSION_VALUE"
-          git push origin "v$NEW_VERSION_VALUE"
 
-      - name: Push new version in release branch & tag
-        run: |
-          git push
+      - name: Create verified commit via API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(beta-release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            package.json
+          tag: 'v${{ steps.create-release.outputs.new_version }}'

--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -41,16 +41,9 @@ jobs:
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 16
-          
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
 
       # Calculate the next release version based on conventional semantic release
-      - name: Create release branch
+      - name: Calculate release version
         id: create-release
         env:
           HUSKY: 0
@@ -74,14 +67,22 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
           echo "NEW_VERSION_VALUE=$new_version" >> $GITHUB_ENV
+
+      - name: Create release branch via GitHub API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse origin/master)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
 
       - name: Bump version
         id: finish-release

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -91,14 +91,23 @@ jobs:
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"
           npx replace $CURRENT_VERSION_VALUE $NEW_VERSION_VALUE README.md sonar-project.properties
-          git add README.md sonar-project.properties
           echo ${{ steps.create-release.outputs.new_version }}
           echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
-          npx standard-version -a --skip.tag
+          # Run standard-version but skip commit and tag - we'll create verified commit via API
+          npx standard-version --skip.commit --skip.tag
 
-      - name: Push new version in release branch & tag
-        run: |
-          git push
+      - name: Create verified commit via API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            CHANGELOG.md
+            package.json
+            README.md
+            sonar-project.properties
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -38,16 +38,9 @@ jobs:
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 16
-          
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
 
       # Calculate the next release version based on conventional semantic release
-      - name: Create release branch
+      - name: Calculate release version
         id: create-release
         env:
           HUSKY: 0
@@ -59,7 +52,7 @@ jobs:
           git fetch --tags origin
           git merge origin/master
           current_version=$(jq -r .version package.json)
-          
+
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(jq -r .version package.json)
           git reset --hard
@@ -71,14 +64,22 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
-          
+
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
           echo "NEW_VERSION_VALUE=$new_version" >> $GITHUB_ENV
+
+      - name: Create release branch via GitHub API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse origin/master)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
 
       - name: Update changelog & bump version
         id: finish-release

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read  # GITHUB_TOKEN only needs read for initial checkout
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/')
@@ -19,9 +19,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and push changes
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set Node 16
@@ -95,7 +105,7 @@ jobs:
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
           pr_reviewer: 'pallabmaiti'

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -46,6 +46,8 @@ on:
 jobs:
   request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -57,4 +59,4 @@ jobs:
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
-          githubKey: ${{ secrets.PAT }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -31,8 +31,9 @@ jobs:
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#hotfix-}
           VERSION=${VERSION#release/}
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
@@ -61,11 +62,12 @@ jobs:
           HUSKY: 0
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
         run: |
           git for-each-ref refs/tags
-          ./Scripts/find-tag.sh ${{ steps.extract-version.outputs.release_version }} && git tag --delete ${{ steps.extract-version.outputs.release_version }} && git push --delete origin ${{ steps.extract-version.outputs.release_version }}
-          git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
-          git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
+          ./Scripts/find-tag.sh "$RELEASE_VERSION" && git tag --delete "$RELEASE_VERSION" && git push --delete origin "$RELEASE_VERSION" || true
+          git tag -a "v$RELEASE_VERSION" -m "chore: release v$RELEASE_VERSION"
+          git push origin "refs/tags/v$RELEASE_VERSION"
           git for-each-ref refs/tags
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -56,18 +56,31 @@ jobs:
           git config user.name "GitHub actions"
           git config user.email noreply@github.com
 
-      - name: Create Github Release & Tag
+      - name: Delete existing tag if present
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
+        run: |
+          git for-each-ref refs/tags
+          ./Scripts/find-tag.sh "v$RELEASE_VERSION" && git tag --delete "v$RELEASE_VERSION" && gh api --method DELETE repos/${{ github.repository }}/git/refs/tags/v$RELEASE_VERSION || true
+
+      - name: Create verified tag
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: master
+          commit-message: 'chore: release v${{ steps.extract-version.outputs.release_version }}'
+          tag: 'v${{ steps.extract-version.outputs.release_version }}'
+          files: ''
+
+      - name: Create Github Release
         id: create_release
         env:
           HUSKY: 0
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
-          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
         run: |
-          git for-each-ref refs/tags
-          ./Scripts/find-tag.sh "$RELEASE_VERSION" && git tag --delete "$RELEASE_VERSION" && git push --delete origin "$RELEASE_VERSION" || true
-          git tag -a "v$RELEASE_VERSION" -m "chore: release v$RELEASE_VERSION"
-          git push origin "refs/tags/v$RELEASE_VERSION"
           git for-each-ref refs/tags
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: read  # GITHUB_TOKEN only needs read for initial checkout
     name: Publish new release
     runs-on: ubuntu-latest
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
@@ -17,6 +19,15 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
+          permission-pull-requests: write # to create and update PRs
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -29,6 +40,7 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set Node 16
@@ -47,8 +59,8 @@ jobs:
         id: create_release
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git for-each-ref refs/tags
           ./Scripts/find-tag.sh ${{ steps.extract-version.outputs.release_version }} && git tag --delete ${{ steps.extract-version.outputs.release_version }} && git push --delete origin ${{ steps.extract-version.outputs.release_version }}


### PR DESCRIPTION
## Summary
Migrates all PAT usages to GITHUB_TOKEN or GitHub App Token, and applies the new simplified release workflow pattern.

### Migration Pattern Evolution

1. The signed-commit action (`ryancyq/github-signed-commit`) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them

### Migration Details

| File | Change | Why |
|------|--------|-----|
| draft-new-release.yml | Simplified with GitHub API branch creation | Removed git config, git checkout -b, git push --set-upstream. Branch now created via `gh api` for cleaner, more secure pattern |
| draft-new-beta-release.yml | Simplified with GitHub API branch creation | Same simplifications - removed git operations replaced by GitHub API |

### Changes Applied

**Removed (no longer needed):**
- `git config user.name/email` steps - signed commit uses App identity
- `git checkout -b` + `git push --set-upstream` - replaced by GitHub API branch creation
- Token-in-URL manipulation with `git remote set-url`

**Added:**
- `Create release branch via GitHub API` step using `gh api repos/.../git/refs`
- Cleaner separation: calculate version locally, create branch via API, then signed-commit action handles the rest

**Unchanged (already correct):**
- GitHub App token generation (early in workflow)
- `standard-version --skip.commit --skip.tag` pattern
- `ryancyq/github-signed-commit` for verified commits
- All permissions and token scoping

### Benefits

- More secure: no token embedded in git URLs
- Cleaner code: fewer git commands
- Better separation of concerns: local calculations vs remote operations
- Works seamlessly with signed-commit action

## Test plan
- [ ] Verify workflows pass after merge
- [ ] Test draft-new-release.yml on a feature branch
- [ ] Test draft-new-beta-release.yml with beta version input

## References
- PAT_MIGRATION_AGENT_PLAN.md - 'Creating Release Branches' section
- PAT_MIGRATION_AGENT_PLAN.md - 'Code Simplification Review' section

🤖 Generated with [Claude Code](https://claude.com/claude-code)