### PR TITLE
fix(vuln): remediate GHA script injection

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -20,10 +20,11 @@ jobs:
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          VERSION=${BRANCH_NAME#hotfix-}
-          VERSION=${VERSION#release/}
+          VERSION="${BRANCH_NAME#hotfix-}"
+          VERSION="${VERSION#release/}"
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout source branch
@@ -49,11 +50,12 @@ jobs:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.PAT }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
         run: |
           git for-each-ref refs/tags
-          ./Scripts/find-tag.sh ${{ steps.extract-version.outputs.release_version }} && git tag --delete ${{ steps.extract-version.outputs.release_version }} && git push --delete origin ${{ steps.extract-version.outputs.release_version }}
-          git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
-          git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
+          ./Scripts/find-tag.sh "$RELEASE_VERSION" && git tag --delete "$RELEASE_VERSION" && git push --delete origin "$RELEASE_VERSION"
+          git tag -a "v${RELEASE_VERSION}" -m "chore: release v${RELEASE_VERSION}"
+          git push origin "refs/tags/v${RELEASE_VERSION}"
           git for-each-ref refs/tags
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js
 


### PR DESCRIPTION
Replaces direct ${{ github.* }} interpolation in run: blocks with env: indirection. Prevents script injection RCE. Ref: SEC-93.